### PR TITLE
search field configuration files for all solr collections

### DIFF
--- a/uniprot-search/src/main/java/org/uniprot/store/search/domain2/UniProtKBSearchFields.java
+++ b/uniprot-search/src/main/java/org/uniprot/store/search/domain2/UniProtKBSearchFields.java
@@ -36,7 +36,7 @@ public enum UniProtKBSearchFields implements SearchFields {
         return searchFieldsLoader.getSortFields();
     }
 
-    private static class UniProtKBSearchFieldsLoader extends SearchFieldsLoader {
+    public static class UniProtKBSearchFieldsLoader extends SearchFieldsLoader {
 
         UniProtKBSearchFieldsLoader(String fileName) {
             super(fileName);

--- a/uniprot-search/src/main/java/org/uniprot/store/search/domain2/UniProtKBSearchFields.java
+++ b/uniprot-search/src/main/java/org/uniprot/store/search/domain2/UniProtKBSearchFields.java
@@ -36,7 +36,7 @@ public enum UniProtKBSearchFields implements SearchFields {
         return searchFieldsLoader.getSortFields();
     }
 
-    public static class UniProtKBSearchFieldsLoader extends SearchFieldsLoader {
+    private static class UniProtKBSearchFieldsLoader extends SearchFieldsLoader {
 
         UniProtKBSearchFieldsLoader(String fileName) {
             super(fileName);

--- a/uniprot-search/src/main/java/org/uniprot/store/search/domain2/UniProtSearchFields.java
+++ b/uniprot-search/src/main/java/org/uniprot/store/search/domain2/UniProtSearchFields.java
@@ -3,7 +3,6 @@ package org.uniprot.store.search.domain2;
 import org.uniprot.core.cv.xdb.UniProtXDbTypes;
 import org.uniprot.store.search.domain2.impl.SearchFieldImpl;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -35,25 +34,6 @@ public enum UniProtSearchFields implements SearchFields {
 
     UniProtSearchFields(String configPath) {
         this.configPath = configPath;
-    }
-
-    public static void main(String[] args) {
-        Arrays.stream(UniProtSearchFields.values())
-                .forEach(
-                        searchFields -> {
-                            System.out.println("--- " + searchFields.name() + " ---");
-                            System.out.println("SearchFields");
-                            searchFields.getSearchFields().stream()
-                                    .map(SearchField::getName)
-                                    .forEach(System.out::println);
-                            System.out.println("SortFields");
-                            searchFields.getSortFields().stream()
-                                    .map(SearchField::getName)
-                                    .forEach(System.out::println);
-                        });
-        UniProtSearchFields.DISEASE.getSearchFields().stream()
-                .map(SearchField::getName)
-                .forEach(System.out::println);
     }
 
     @Override

--- a/uniprot-search/src/main/java/org/uniprot/store/search/domain2/UniProtSearchFields.java
+++ b/uniprot-search/src/main/java/org/uniprot/store/search/domain2/UniProtSearchFields.java
@@ -1,0 +1,106 @@
+package org.uniprot.store.search.domain2;
+
+import org.uniprot.core.cv.xdb.UniProtXDbTypes;
+import org.uniprot.store.search.domain2.impl.SearchFieldImpl;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Represents all accessible search fields for UniProt domains (e.g., UniProtKB, UniParc, UniRef),
+ * and provides access to them via the {@link SearchFields} contract.
+ *
+ * <p>Created 17/01/2020
+ *
+ * @author Edd
+ */
+public enum UniProtSearchFields implements SearchFields {
+    CROSSREF("crossref/search-fields.json"),
+    DISEASE("disease/search-fields.json"),
+    GENECENTRIC("gene-centric/search-fields.json"),
+    KEYWORD("keyword/search-fields.json"),
+    LITERATURE("literature/search-fields.json"),
+    PROTEOME("proteome/search-fields.json"),
+    SUBCELL("subcell-location/search-fields.json"),
+    TAXONOMY("taxonomy/search-fields.json"),
+    UNIPARC("uniparc/search-fields.json"),
+    UNIPROTKB("uniprot/search-fields.json"),
+    UNIREF("uniref/search-fields.json");
+
+    private String configPath;
+    private SearchFieldsLoader searchFieldsLoader;
+
+    UniProtSearchFields(String configPath) {
+        this.configPath = configPath;
+    }
+
+    public static void main(String[] args) {
+        Arrays.stream(UniProtSearchFields.values())
+                .forEach(
+                        searchFields -> {
+                            System.out.println("--- " + searchFields.name() + " ---");
+                            System.out.println("SearchFields");
+                            searchFields.getSearchFields().stream()
+                                    .map(SearchField::getName)
+                                    .forEach(System.out::println);
+                            System.out.println("SortFields");
+                            searchFields.getSortFields().stream()
+                                    .map(SearchField::getName)
+                                    .forEach(System.out::println);
+                        });
+        UniProtSearchFields.DISEASE.getSearchFields().stream()
+                .map(SearchField::getName)
+                .forEach(System.out::println);
+    }
+
+    @Override
+    public Set<SearchField> getSearchFields() {
+        checkInitialised();
+        return searchFieldsLoader.getSearchFields();
+    }
+
+    @Override
+    public Set<SearchField> getSortFields() {
+        checkInitialised();
+        return searchFieldsLoader.getSortFields();
+    }
+
+    private void checkInitialised() {
+        if (Objects.isNull(searchFieldsLoader)) {
+            if (configPath.startsWith("uniprot")) {
+                searchFieldsLoader = new UniProtKBSearchFieldsLoader(configPath);
+            } else {
+                searchFieldsLoader = new SearchFieldsLoader(configPath);
+            }
+        }
+    }
+
+    private static class UniProtKBSearchFieldsLoader extends SearchFieldsLoader {
+        private static final String XREF_COUNT_PREFIX = "xref_count_";
+
+        UniProtKBSearchFieldsLoader(String fileName) {
+            super(fileName);
+        }
+
+        @Override
+        protected List<SearchField> extractSearchFields(List<SearchItem> allSearchItems) {
+            List<SearchField> searchFields = super.extractSearchFields(allSearchItems);
+            searchFields.addAll(getDbXrefsCountSearchFields());
+            return searchFields;
+        }
+
+        private List<SearchFieldImpl> getDbXrefsCountSearchFields() {
+            return UniProtXDbTypes.INSTANCE.getAllDBXRefTypes().stream()
+                    .map(
+                            db ->
+                                    SearchFieldImpl.builder()
+                                            .name(XREF_COUNT_PREFIX + db.getName().toLowerCase())
+                                            .type(SearchFieldType.RANGE)
+                                            .build())
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/uniprot-search/src/main/resources/crossref/search-fields.json
+++ b/uniprot-search/src/main/resources/crossref/search-fields.json
@@ -1,0 +1,20 @@
+[
+  {
+    "field": "accession",
+    "fieldValidRegex": "^DB-[0-9]{4}$",
+    "sortField": "accession"
+  },
+  {
+    "field": "category_str",
+    "sortField": "category_str"
+  },
+  {
+    "field": "name"
+  },
+  {
+    "field": "category_facet"
+  },
+  {
+    "field": "content"
+  }
+]

--- a/uniprot-search/src/main/resources/disease/search-fields.json
+++ b/uniprot-search/src/main/resources/disease/search-fields.json
@@ -1,0 +1,12 @@
+[
+  {
+    "field": "accession",
+    "sortField": "accession"
+  },
+  {
+    "field": "name"
+  },
+  {
+    "field": "content"
+  }
+]

--- a/uniprot-search/src/main/resources/gene-centric/search-fields.json
+++ b/uniprot-search/src/main/resources/gene-centric/search-fields.json
@@ -1,0 +1,29 @@
+[
+  {
+    "field": "accession_id",
+    "fieldValidRegex": "([O,P,Q][0-9][A-Z|0-9]{3}[0-9]|[A-N,R-Z]([0-9][A-Z][A-Z|0-9]{2}){1,2}[0-9])(-\\d+)*",
+    "sortField": "accession_id"
+  },
+  {
+    "field": "accession",
+    "fieldValidRegex": "([O,P,Q][0-9][A-Z|0-9]{3}[0-9]|[A-N,R-Z]([0-9][A-Z][A-Z|0-9]{2}){1,2}[0-9])(-\\d+)*"
+  },
+  {
+    "field": "upid",
+    "fieldValidRegex": "^UP[0-9]{9}$"
+  },
+  {
+    "field": "organism_id",
+    "fieldValidRegex": "^[0-9]+$"
+  },
+  {
+    "field": "gene"
+  },
+  {
+    "field": "reviewed",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "content"
+  }
+]

--- a/uniprot-search/src/main/resources/keyword/search-fields.json
+++ b/uniprot-search/src/main/resources/keyword/search-fields.json
@@ -1,0 +1,23 @@
+[
+  {
+    "field": "name",
+    "sortField": "name_sort"
+  },
+  {
+    "field": "id",
+    "fieldValidRegex": "^KW-[0-9]{4}$"
+  },
+  {
+    "field": "keyword_id",
+    "fieldValidRegex": "^KW-[0-9]{4}$"
+  },
+  {
+    "field": "ancestor"
+  },
+  {
+    "field": "parent"
+  },
+  {
+    "field": "content"
+  }
+]

--- a/uniprot-search/src/main/resources/literature/search-fields.json
+++ b/uniprot-search/src/main/resources/literature/search-fields.json
@@ -1,0 +1,30 @@
+[
+  {
+    "field": "id",
+    "fieldValidRegex": "^[0-9]+$",
+    "sortField": "id_sort"
+  },
+  {
+    "field": "title"
+  },
+  {
+    "field": "author"
+  },
+  {
+    "field": "journal"
+  },
+  {
+    "field": "published"
+  },
+  {
+    "field": "citedin",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "mappedin",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "content"
+  }
+]

--- a/uniprot-search/src/main/resources/proteome/search-fields.json
+++ b/uniprot-search/src/main/resources/proteome/search-fields.json
@@ -1,0 +1,49 @@
+[
+  {
+    "field": "upid",
+    "fieldValidRegex": "UP[0-9]{9}"
+  },
+  {
+    "field": "proteome_type"
+  },
+  {
+    "field": "annotation_score"
+  },
+  {
+    "field": "organism_sort"
+  },
+  {
+    "field": "reference",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "redundant",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "organism_name"
+  },
+  {
+    "field": "organism_id",
+    "fieldValidRegex": "^[0-9]+$"
+  },
+  {
+    "field": "taxonomy_name"
+  },
+  {
+    "field": "taxonomy_id",
+    "fieldValidRegex": "^[0-9]+$"
+  },
+  {
+    "field": "superkingdom"
+  },
+  {
+    "field": "genome_accession"
+  },
+  {
+    "field": "genome_assembly"
+  },
+  {
+    "field": "content"
+  }
+]

--- a/uniprot-search/src/main/resources/subcell-location/search-fields.json
+++ b/uniprot-search/src/main/resources/subcell-location/search-fields.json
@@ -1,0 +1,17 @@
+[
+  {
+    "field": "name",
+    "sortField": "name_sort"
+  },
+  {
+    "field": "id",
+    "sortField": "id",
+    "fieldValidRegex": "^SL-[0-9]{4}$"
+  },
+  {
+    "field": "category"
+  },
+  {
+    "field": "content"
+  }
+]

--- a/uniprot-search/src/main/resources/taxonomy/search-fields.json
+++ b/uniprot-search/src/main/resources/taxonomy/search-fields.json
@@ -1,0 +1,60 @@
+[
+  {
+    "field": "name",
+    "sortField": "name"
+  },
+  {
+    "field": "id",
+    "fieldValidRegex": "^[0-9]+$"
+  },
+  {
+    "field": "tax_id",
+    "fieldValidRegex": "^[0-9]+$"
+  },
+  {
+    "field": "scientific"
+  },
+  {
+    "field": "common"
+  },
+  {
+    "field": "mnemonic"
+  },
+  {
+    "field": "rank"
+  },
+  {
+    "field": "strain"
+  },
+  {
+    "field": "host",
+    "fieldValidRegex": "^[0-9]+$"
+  },
+  {
+    "field": "linked",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "active",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "proteome",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "reference",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "reviewed",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "annotated",
+    "fieldValidRegex": "^true|false$"
+  },
+  {
+    "field": "content"
+  }
+]

--- a/uniprot-search/src/main/resources/uniparc/search-fields.json
+++ b/uniprot-search/src/main/resources/uniparc/search-fields.json
@@ -1,0 +1,48 @@
+[
+  {
+    "field": "upi",
+    "sortField": "upi",
+    "fieldValidRegex": "UPI[\\w]{10}"
+  },
+  {
+    "field": "accession",
+    "fieldValidRegex": "([O,P,Q][0-9][A-Z|0-9]{3}[0-9]|[A-N,R-Z]([0-9][A-Z][A-Z|0-9]{2}){1,2}[0-9])"
+  },
+  {
+    "field": "isoform",
+    "fieldValidRegex": "([O,P,Q][0-9][A-Z|0-9]{3}[0-9]|[A-N,R-Z]([0-9][A-Z][A-Z|0-9]{2}){1,2}[0-9])"
+  },
+  {
+    "field": "upid",
+    "fieldValidRegex": "UPI[\\w]{10}"
+  },
+  {
+    "field": "taxonomy_id",
+    "fieldValidRegex": "^[0-9]+$"
+  },
+  {
+    "field": "taxonomy_name"
+  },
+  {
+    "field": "gene"
+  },
+  {
+    "field": "protein"
+  },
+  {
+    "field": "database"
+  },
+  {
+    "field": "active"
+  },
+  {
+    "field": "checksum"
+  },
+  {
+    "field": "length",
+    "sortField": "upi"
+  },
+  {
+    "field": "content"
+  }
+]

--- a/uniprot-search/src/main/resources/uniref/search-fields.json
+++ b/uniprot-search/src/main/resources/uniref/search-fields.json
@@ -1,0 +1,45 @@
+[
+  {
+    "field": "id",
+    "fieldValidRegex": "(UniRef100|UniRef90|UniRef50)\\w*",
+    "sortField": "id"
+  },
+  {
+    "field": "organism_sort",
+    "sortField": "organism_sort"
+  },
+  {
+    "field": "name"
+  },
+  {
+    "field": "identity"
+  },
+  {
+    "field": "count",
+    "sortField": "count"
+  },
+  {
+    "field": "length",
+    "sortField": "length"
+  },
+  {
+    "field": "created"
+  },
+  {
+    "field": "uniprot_id"
+  },
+  {
+    "field": "upi",
+    "fieldValidRegex": "UPI[\\w]{10}"
+  },
+  {
+    "field": "taxonomy_id",
+    "fieldValidRegex": "^[0-9]+$"
+  },
+  {
+    "field": "taxonomy_name"
+  } ,
+  {
+    "field": "content"
+  }
+]

--- a/uniprot-search/src/test/java/org/uniprot/store/search/domain2/UniProtSearchFieldsTest.java
+++ b/uniprot-search/src/test/java/org/uniprot/store/search/domain2/UniProtSearchFieldsTest.java
@@ -1,0 +1,25 @@
+package org.uniprot.store.search.domain2;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * The purpose of this test class is to ensure all the configuration files for the search fields can
+ * be loaded correctly. The contents of the tests need not be comprehensive, just check that search
+ * fields exist.
+ *
+ * <p>Created 17/01/2020
+ *
+ * @author Edd
+ */
+class UniProtSearchFieldsTest {
+    @ParameterizedTest
+    @EnumSource(UniProtSearchFields.class)
+    void canLoadFields(UniProtSearchFields searchFields) {
+        assertThat(searchFields.getSearchFields(), hasSize(greaterThan(0)));
+        assertThat(searchFields.getSearchFields(), is(notNullValue()));
+    }
+}


### PR DESCRIPTION
Add search field configuration files for all solr collections, and make them available via a `SearchField` enum.