### PR TITLE
add seedId to UniRefEntry

### DIFF
--- a/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/uniref/converter/DatasetUniRefEntryLightConverter.java
+++ b/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/uniref/converter/DatasetUniRefEntryLightConverter.java
@@ -8,10 +8,7 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.sql.Row;
@@ -73,7 +70,11 @@ public class DatasetUniRefEntryLightConverter
             // member accessions
             builder.sequence(representativeMember.getSequence().getValue());
 
-            builder.representativeId(representativeMember.getMemberId());
+            String representativeId = representativeMember.getMemberId();
+            if (Utils.notNullNotEmpty(representativeMember.getUniProtAccessions())) {
+                representativeId += "," + representativeMember.getUniProtAccessions().get(0);
+            }
+            builder.representativeId(representativeId);
 
             addMemberInfo(builder, representativeMember);
         }
@@ -138,7 +139,7 @@ public class DatasetUniRefEntryLightConverter
             builder.membersAdd(uniparcId + "," + memberType);
         }
         if (Utils.notNull(member.isSeed()) && member.isSeed()) {
-            builder.seedId(member.getMemberId());
+            builder.seedId(getSeedIdFromMember(member));
         }
 
         builder.memberIdTypesAdd(member.getMemberIdType());
@@ -201,5 +202,14 @@ public class DatasetUniRefEntryLightConverter
         if (propertyMap.containsKey(PROPERTY_IS_SEED)) {
             builder.isSeed(Boolean.parseBoolean(propertyMap.get(PROPERTY_IS_SEED).get(0)));
         }
+    }
+
+    private String getSeedIdFromMember(UniRefMember member) {
+        String seedId = member.getMemberId();
+        if (Utils.notNullNotEmpty(member.getUniProtAccessions())) {
+            String accession = member.getUniProtAccessions().get(0).getValue();
+            seedId += "," + accession;
+        }
+        return seedId;
     }
 }

--- a/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/uniref/converter/DatasetUniRefEntryLightConverterTest.java
+++ b/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/uniref/converter/DatasetUniRefEntryLightConverterTest.java
@@ -55,7 +55,7 @@ class DatasetUniRefEntryLightConverterTest {
         assertEquals("common taxon Value", entry.getCommonTaxon());
         assertEquals(9606, entry.getCommonTaxonId());
         assertEquals(10, entry.getMemberCount());
-        assertEquals("FGFR2_HUMAN", entry.getSeedId());
+        assertEquals("FGFR2_HUMAN,P12345", entry.getSeedId());
 
         assertEquals(3, entry.getGoTerms().size());
         GeneOntologyEntry goTerm = entry.getGoTerms().get(0);
@@ -66,7 +66,7 @@ class DatasetUniRefEntryLightConverterTest {
         assertThat(entry.getMembers(), contains("R12345,0", "P12345,0", "UPI0003447082,3"));
 
         // representative
-        assertThat(entry.getRepresentativeId(), is("FGFR2_HUMAN"));
+        assertThat(entry.getRepresentativeId(), is("FGFR2_HUMAN,R12345"));
         assertThat(entry.getName(), is("Cluster: Fibroblast growth factor receptor 2"));
         assertThat(entry.getRepresentativeProteinName(), is("Fibroblast growth factor receptor 2"));
         assertThat(entry.getSequence(), is("MVSWGRFICLVVVTMATLSLAR"));


### PR DESCRIPTION
- Add seedId to UniRefEntry. The seedId is storing UniprotKB accession or UniParcId if the member type is UniParc.
- Update seedId and ReferenceId values in UniRefEntryLight to accession, to make it consistent with seedId in UniRefEntry.

The idea is that we display accession for seedId in both entities (UniRefEntry and UniRefEntryLight) 