### PR TITLE
uniparc accession filtering

### DIFF
--- a/uniprot-config/src/main/resources/return-fields-config/uniparc-return-fields.json
+++ b/uniprot-config/src/main/resources/return-fields-config/uniparc-return-fields.json
@@ -128,7 +128,7 @@
     "defaultForTsvOrder" : 2,
     "label": "UniProtKB",
     "name": "accession",
-    "paths": ["uniParcCrossReferences[*].properties[?(@.key=='UniProtKB_accession')]"],
+    "paths": ["uniParcCrossReferences[?(@.database =~ /^UniProtKB.*/)]"],
     "id": "miscellaneous/accession",
     "includeInSwagger": true
   },


### PR DESCRIPTION
changing test that mocked "UniProtKB_accession" property in uniparc json xrefs, which doesn't seem to exist.

done because front-end found that accession filtering on uniparc responses gave empty results.