### PR TITLE
fix Lineage hidden field for Proteome Entry

### DIFF
--- a/indexer/src/main/java/org/uniprot/store/indexer/proteome/ProteomeEntryAdapter.java
+++ b/indexer/src/main/java/org/uniprot/store/indexer/proteome/ProteomeEntryAdapter.java
@@ -117,6 +117,7 @@ public class ProteomeEntryAdapter {
                                         new TaxonomyLineageBuilder()
                                                 .taxonId(node.id())
                                                 .scientificName(node.scientificName())
+                                                .hidden(node.hidden())
                                                 .build())
                         .collect(Collectors.toList());
         return Lists.reverse(lineage);

--- a/indexer/src/main/java/org/uniprot/store/indexer/proteome/ProteomeEntryAdapter.java
+++ b/indexer/src/main/java/org/uniprot/store/indexer/proteome/ProteomeEntryAdapter.java
@@ -16,6 +16,7 @@ import org.uniprot.core.proteome.ProteomeEntry;
 import org.uniprot.core.proteome.Superkingdom;
 import org.uniprot.core.proteome.impl.ProteomeEntryBuilder;
 import org.uniprot.core.taxonomy.TaxonomyLineage;
+import org.uniprot.core.taxonomy.TaxonomyRank;
 import org.uniprot.core.taxonomy.impl.TaxonomyLineageBuilder;
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 import org.uniprot.core.uniprotkb.taxonomy.impl.TaxonomyBuilder;
@@ -117,7 +118,9 @@ public class ProteomeEntryAdapter {
                                         new TaxonomyLineageBuilder()
                                                 .taxonId(node.id())
                                                 .scientificName(node.scientificName())
+                                                .commonName(node.commonName())
                                                 .hidden(node.hidden())
+                                                .rank(TaxonomyRank.typeOf(node.rank()))
                                                 .build())
                         .collect(Collectors.toList());
         return Lists.reverse(lineage);

--- a/indexer/src/main/java/org/uniprot/store/indexer/taxonomy/TaxonomySQLConstants.java
+++ b/indexer/src/main/java/org/uniprot/store/indexer/taxonomy/TaxonomySQLConstants.java
@@ -2,6 +2,9 @@ package org.uniprot.store.indexer.taxonomy;
 
 public class TaxonomySQLConstants {
 
+    private TaxonomySQLConstants(){
+    }
+
     public static final String SELECT_TAXONOMY_NODE_SQL =
             "SELECT tax_id,parent_id,hidden,internal,rank,gc_id,mgc_id,"
                     + "ncbi_scientific,ncbi_common,sptr_scientific,sptr_common,sptr_synonym,sptr_code,tax_code,sptr_ff,superregnum"
@@ -21,6 +24,7 @@ public class TaxonomySQLConstants {
             "SELECT"
                     + "   SYS_CONNECT_BY_PATH(TAX_ID, '|') AS lineage_id,"
                     + "   SYS_CONNECT_BY_PATH(SPTR_SCIENTIFIC, '|') AS lineage_name,"
+                    + "   SYS_CONNECT_BY_PATH(COALESCE(SPTR_COMMON, NCBI_COMMON, ' '), '|') AS lineage_common,"
                     + "   SYS_CONNECT_BY_PATH(RANK, '|') AS lineage_rank,"
                     + "   SYS_CONNECT_BY_PATH(HIDDEN, '|') AS lineage_hidden"
                     + " FROM taxonomy.V_PUBLIC_NODE"

--- a/indexer/src/main/java/org/uniprot/store/indexer/taxonomy/readers/TaxonomyLineageReader.java
+++ b/indexer/src/main/java/org/uniprot/store/indexer/taxonomy/readers/TaxonomyLineageReader.java
@@ -19,17 +19,22 @@ public class TaxonomyLineageReader implements RowMapper<List<TaxonomyLineage>> {
         List<TaxonomyLineage> lineageList = new ArrayList<>();
         String lineageIds = resultSet.getString("lineage_id");
         String lineageName = resultSet.getString("lineage_name");
+        String lineageCommon = resultSet.getString("lineage_common");
         String lineageRank = resultSet.getString("lineage_rank");
         String lineageHidden = resultSet.getString("lineage_hidden");
         if (Utils.notNullNotEmpty(lineageIds)) {
             String[] lineageIdArray = lineageIds.substring(1).split("\\|");
             String[] lineageNameArray = lineageName.substring(1).split("\\|");
+            String[] lineageCommonArray = lineageCommon.substring(1).split("\\|");
             String[] lineageRankArray = lineageRank.substring(1).split("\\|");
             String[] lineageHiddenArray = lineageHidden.substring(1).split("\\|");
             for (int i = 1; i < lineageIdArray.length - 1; i++) {
                 TaxonomyLineageBuilder builder = new TaxonomyLineageBuilder();
                 builder.taxonId(Long.parseLong(lineageIdArray[i]));
                 builder.scientificName(lineageNameArray[i]);
+                if (Utils.notNullNotEmpty(lineageCommonArray[i])) {
+                    builder.commonName(lineageCommonArray[i]);
+                }
                 if (Utils.notNullNotEmpty(lineageRankArray[i])) {
                     try {
                         builder.rank(TaxonomyRank.valueOf(lineageRankArray[i].toUpperCase()));

--- a/indexer/src/test/java/org/uniprot/store/indexer/proteome/ProteomeEntryAdapterTest.java
+++ b/indexer/src/test/java/org/uniprot/store/indexer/proteome/ProteomeEntryAdapterTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.uniprot.core.proteome.ProteomeEntry;
 import org.uniprot.core.proteome.Superkingdom;
 import org.uniprot.core.taxonomy.TaxonomyLineage;
+import org.uniprot.core.taxonomy.TaxonomyRank;
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 import org.uniprot.core.xml.jaxb.proteome.ObjectFactory;
 import org.uniprot.core.xml.jaxb.proteome.Proteome;
@@ -71,6 +72,8 @@ class ProteomeEntryAdapterTest {
         TaxonomyLineage lineage = lineages.get(0);
         assertEquals(2, lineage.getTaxonId());
         assertEquals("Bacteria", lineage.getScientificName());
+        assertEquals("Bacteria", lineage.getCommonName());
+        assertEquals(TaxonomyRank.SUPERKINGDOM, lineage.getRank());
         assertFalse(lineage.isHidden());
     }
 

--- a/indexer/src/test/java/org/uniprot/store/indexer/proteome/ProteomeEntryAdapterTest.java
+++ b/indexer/src/test/java/org/uniprot/store/indexer/proteome/ProteomeEntryAdapterTest.java
@@ -71,6 +71,7 @@ class ProteomeEntryAdapterTest {
         TaxonomyLineage lineage = lineages.get(0);
         assertEquals(2, lineage.getTaxonId());
         assertEquals("Bacteria", lineage.getScientificName());
+        assertFalse(lineage.isHidden());
     }
 
     @Test

--- a/indexer/src/test/java/org/uniprot/store/indexer/taxonomy/TaxonomyJobIT.java
+++ b/indexer/src/test/java/org/uniprot/store/indexer/taxonomy/TaxonomyJobIT.java
@@ -217,6 +217,7 @@ class TaxonomyJobIT {
         TaxonomyLineage lineage = entry.getLineages().get(0);
         assertThat(lineage.getTaxonId(), is(4L));
         assertThat(lineage.getScientificName(), is("name4"));
+        assertThat(lineage.getCommonName(), is("common4"));
         assertThat(lineage.getRank(), is(TaxonomyRank.KINGDOM));
         assertThat(lineage.isHidden(), is(true));
 
@@ -259,6 +260,7 @@ class TaxonomyJobIT {
         protected String getTaxonomyLineageSQL() {
             return "SELECT '|5|4|1' as lineage_id,"
                     + "      '|name5|name4|name1' AS lineage_name,"
+                    + "      '|common5|common4|common1' AS lineage_common,"
                     + "      '|rank5|KINGDOM|rank1' AS lineage_rank,"
                     + "      '|0|1|0' AS lineage_hidden"
                     + " FROM taxonomy.V_PUBLIC_NODE"

--- a/indexer/src/test/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtKBEntryConverterIT.java
+++ b/indexer/src/test/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtKBEntryConverterIT.java
@@ -95,7 +95,7 @@ class UniProtKBEntryConverterIT {
     @Test
     void testConvertFullA0PHU1Entry() throws Exception {
         when(repoMock.retrieveNodeUsingTaxID(anyInt()))
-                .thenReturn(getTaxonomyNode(172543, "Cichlasoma festae", null, null, null));
+                .thenReturn(getTaxonomyNode(172543, "Cichlasoma festae", null, null, null, "SPECIES"));
         Set<GeneOntologyEntry> ancestors = new HashSet<>();
         ancestors.addAll(getMockParentGoTerm());
         ancestors.addAll(getMockPartOfGoTerm());
@@ -232,7 +232,7 @@ class UniProtKBEntryConverterIT {
     @Test
     void testConvertFullQ9EPI6Entry() throws Exception {
         when(repoMock.retrieveNodeUsingTaxID(anyInt()))
-                .thenReturn(getTaxonomyNode(10116, "Rattus norvegicus", "Rat", null, null));
+                .thenReturn(getTaxonomyNode(10116, "Rattus norvegicus", "Rat", null, null, "SPECIES"));
         ChebiEntry chebiId1 =
                 new ChebiEntryBuilder()
                         .id("15379")
@@ -448,7 +448,7 @@ class UniProtKBEntryConverterIT {
     @Test
     void testConvertIsoformEntry() throws Exception {
         when(repoMock.retrieveNodeUsingTaxID(anyInt()))
-                .thenReturn(getTaxonomyNode(10116, "Rattus norvegicus", "Rat", null, null));
+                .thenReturn(getTaxonomyNode(10116, "Rattus norvegicus", "Rat", null, null, "SPECIES"));
 
         String file = "Q9EPI6-2.sp";
         UniProtKBEntry entry = parse(file);
@@ -683,7 +683,7 @@ class UniProtKBEntryConverterIT {
     }
 
     private Optional<TaxonomicNode> getTaxonomyNode(
-            int id, String scientificName, String commonName, String synonym, String mnemonic) {
+            int id, String scientificName, String commonName, String synonym, String mnemonic, String rank) {
         return Optional.of(
                 new TaxonomicNode() {
                     @Override
@@ -714,6 +714,11 @@ class UniProtKBEntryConverterIT {
                     @Override
                     public boolean hidden() {
                         return false;
+                    }
+
+                    @Override
+                    public String rank() {
+                        return rank;
                     }
 
                     @Override

--- a/indexer/src/test/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtKBEntryConverterIT.java
+++ b/indexer/src/test/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtKBEntryConverterIT.java
@@ -712,6 +712,11 @@ class UniProtKBEntryConverterIT {
                     }
 
                     @Override
+                    public boolean hidden() {
+                        return false;
+                    }
+
+                    @Override
                     public TaxonomicNode parent() {
                         return null;
                     }

--- a/indexer/src/test/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtKBEntryTaxonomyConverterTest.java
+++ b/indexer/src/test/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtKBEntryTaxonomyConverterTest.java
@@ -82,11 +82,11 @@ class UniProtKBEntryTaxonomyConverterTest {
         assertTrue(suggestions.containsKey("ORGANISM:9606"));
 
         SuggestDocument suggestionDocument = suggestions.get("ORGANISM:9606");
-        assertEquals(suggestionDocument.id, "9606");
-        assertEquals(suggestionDocument.value, "Homo sapiens");
-        assertEquals(suggestionDocument.altValues, asList("Human", "Homo sapian", "HUMAN"));
-        assertEquals(suggestionDocument.dictionary, "ORGANISM");
-        assertEquals(suggestionDocument.importance, "medium");
+        assertEquals( "9606", suggestionDocument.id);
+        assertEquals("Homo sapiens", suggestionDocument.value);
+        assertEquals(asList("Human", "Homo sapian", "HUMAN"), suggestionDocument.altValues);
+        assertEquals("ORGANISM", suggestionDocument.dictionary);
+        assertEquals("medium", suggestionDocument.importance);
 
         assertTrue(suggestions.containsKey("TAXONOMY:9606"));
         assertTrue(suggestions.containsKey("TAXONOMY:9605"));
@@ -129,7 +129,7 @@ class UniProtKBEntryTaxonomyConverterTest {
         assertNull(uniProtDocument.modelOrganism);
 
         // lineage fields
-        assertEquals(asList(9000), uniProtDocument.taxLineageIds);
+        assertEquals(singletonList(9000), uniProtDocument.taxLineageIds);
         assertEquals(asList("other scientific", "other synonym"), uniProtDocument.organismTaxon);
 
         // suggestion documents for organism and taxonomy lineage...
@@ -137,11 +137,11 @@ class UniProtKBEntryTaxonomyConverterTest {
         assertTrue(suggestions.containsKey("ORGANISM:9000"));
 
         SuggestDocument suggestionDocument = suggestions.get("ORGANISM:9000");
-        assertEquals(suggestionDocument.id, "9000");
-        assertEquals(suggestionDocument.value, "other scientific");
-        assertEquals(suggestionDocument.altValues, asList("other synonym"));
-        assertEquals(suggestionDocument.dictionary, "ORGANISM");
-        assertEquals(suggestionDocument.importance, "medium");
+        assertEquals("9000", suggestionDocument.id);
+        assertEquals("other scientific", suggestionDocument.value);
+        assertEquals(singletonList("other synonym"), suggestionDocument.altValues);
+        assertEquals("ORGANISM", suggestionDocument.dictionary);
+        assertEquals("medium", suggestionDocument.importance);
 
         assertTrue(suggestions.containsKey("TAXONOMY:9000"));
     }
@@ -177,11 +177,11 @@ class UniProtKBEntryTaxonomyConverterTest {
         assertTrue(suggestions.containsKey("HOST:9606"));
 
         SuggestDocument suggestionDocument = suggestions.get("HOST:9606");
-        assertEquals(suggestionDocument.id, "9606");
-        assertEquals(suggestionDocument.value, "Homo sapiens");
-        assertEquals(suggestionDocument.altValues, asList("Human", "Homo sapian", "HUMAN"));
-        assertEquals(suggestionDocument.dictionary, "HOST");
-        assertEquals(suggestionDocument.importance, "medium");
+        assertEquals("9606", suggestionDocument.id );
+        assertEquals("Homo sapiens", suggestionDocument.value);
+        assertEquals(asList("Human", "Homo sapian", "HUMAN"), suggestionDocument.altValues);
+        assertEquals("HOST", suggestionDocument.dictionary);
+        assertEquals("medium", suggestionDocument.importance);
     }
 
     @Test
@@ -228,11 +228,11 @@ class UniProtKBEntryTaxonomyConverterTest {
         assertTrue(suggestions.containsKey("HOST:9000"));
 
         SuggestDocument suggestionDocument = suggestions.get("HOST:9606");
-        assertEquals(suggestionDocument.id, "9606");
-        assertEquals(suggestionDocument.value, "Homo sapiens");
-        assertEquals(suggestionDocument.altValues, asList("Human", "Homo sapian", "HUMAN"));
-        assertEquals(suggestionDocument.dictionary, "HOST");
-        assertEquals(suggestionDocument.importance, "medium");
+        assertEquals("9606", suggestionDocument.id);
+        assertEquals("Homo sapiens", suggestionDocument.value);
+        assertEquals(asList("Human", "Homo sapian", "HUMAN"), suggestionDocument.altValues);
+        assertEquals("HOST", suggestionDocument.dictionary);
+        assertEquals("medium", suggestionDocument.importance);
     }
 
     private TaxonomicNode getTaxonomyNode(
@@ -266,6 +266,11 @@ class UniProtKBEntryTaxonomyConverterTest {
             @Override
             public String mnemonic() {
                 return mnemonic;
+            }
+
+            @Override
+            public boolean hidden() {
+                return false;
             }
 
             @Override

--- a/indexer/src/test/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtKBEntryTaxonomyConverterTest.java
+++ b/indexer/src/test/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtKBEntryTaxonomyConverterTest.java
@@ -274,6 +274,11 @@ class UniProtKBEntryTaxonomyConverterTest {
             }
 
             @Override
+            public String rank() {
+                return null;
+            }
+
+            @Override
             public TaxonomicNode parent() {
                 return parent;
             }


### PR DESCRIPTION
ProteomeEntry has a List of TaxonomyLineage objects, and TaxonomyLineage hidden field was always false because we were not loading it from taxonomy.data file. Now hidden is displayed properly