### PR TITLE
TRM-27044: Publication category improve

### DIFF
--- a/common-job/src/main/java/org/uniprot/store/reader/publications/AbstractMappedReferenceConverter.java
+++ b/common-job/src/main/java/org/uniprot/store/reader/publications/AbstractMappedReferenceConverter.java
@@ -1,6 +1,7 @@
 package org.uniprot.store.reader.publications;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,10 +37,7 @@ abstract class AbstractMappedReferenceConverter<T extends MappedReference>
         int prevCatEnd = 0;
         while (matcher.find() && prevCatEnd == matcher.start()) {
             String category = matcher.group(1);
-            if (isValidCategory(category)) {
-                categories.add(category);
-            }
-
+            getValidCategory(category).ifPresent(categories::add);
             prevCatEnd = matcher.end();
         }
 
@@ -87,7 +85,7 @@ abstract class AbstractMappedReferenceConverter<T extends MappedReference>
 
     abstract T convertRawMappedReference(RawMappedReference reference);
 
-    private static boolean isValidCategory(String category) {
-        return CATEGORIES.contains(category);
+    private static Optional<String> getValidCategory(String category) {
+        return CATEGORIES.stream().filter(cat -> cat.equalsIgnoreCase(category)).findFirst();
     }
 }

--- a/common-job/src/test/java/org/uniprot/store/reader/publications/CommunityMappedReferenceConverterTest.java
+++ b/common-job/src/test/java/org/uniprot/store/reader/publications/CommunityMappedReferenceConverterTest.java
@@ -64,4 +64,21 @@ class CommunityMappedReferenceConverterTest {
         assertThat(communityAnnotation.getComment(), is("Peas"));
         assertThat(communityAnnotation.getDisease(), is("This is a disease."));
     }
+
+    @Test
+    void convertsCorrectlyMultipleAnnotationsAndMultipleCategories() throws IOException {
+        CommunityMappedReferenceConverter mapper = new CommunityMappedReferenceConverter();
+        CommunityMappedReference reference =
+                mapper.convert(
+                        "COMM03\tORCID\t00000003\t0000-0002-7460-6676\t[Function][Subcellular location]Protein/gene_name: EnvP(b). Function: Fusogenic properties.\n");
+
+        assertThat(reference.getUniProtKBAccession().getValue(), is("COMM03"));
+        assertThat(
+                reference.getSource(),
+                is(new MappedSourceBuilder().name("ORCID").id("0000-0002-7460-6676").build()));
+        assertThat(reference.getCitationId(), is("00000003"));
+        assertThat(reference.getSourceCategories(), contains("Function", "Subcellular Location"));
+        assertThat(reference.getCommunityAnnotation().getProteinOrGene(), is("EnvP(b)"));
+        assertThat(reference.getCommunityAnnotation().getFunction(), is("Fusogenic properties."));
+    }
 }

--- a/common-job/src/test/java/org/uniprot/store/reader/publications/ComputationallyMappedReferenceConverterTest.java
+++ b/common-job/src/test/java/org/uniprot/store/reader/publications/ComputationallyMappedReferenceConverterTest.java
@@ -2,6 +2,7 @@ package org.uniprot.store.reader.publications;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.core.Is.is;
 
 import java.io.IOException;
@@ -34,5 +35,21 @@ class ComputationallyMappedReferenceConverterTest {
                 reference.getAnnotation(),
                 is(
                         "Protein/gene_name: BraC3; RL3540. Function: BraC3 is an alternative substrate binding component of the ABC transporter braDEFGC. BraC3 supports the transport of leucine, isoleucine, valine, or alanine, but not glutamate or aspartate. Comments: Transport of branched amino acids by either BraC3 (with BraDEFG) or AapJQMP is required for symbiosis with peas."));
+    }
+
+    @Test
+    void convertsCorrectlyWithoutAnnotation() throws IOException {
+        ComputationallyMappedReferenceConverter mapper =
+                new ComputationallyMappedReferenceConverter();
+        ComputationallyMappedReference reference =
+                mapper.convert("P17427\tMGI\t23640057\t101920\t[Function][Subcellular Location]\n");
+
+        assertThat(reference.getUniProtKBAccession().getValue(), is("P17427"));
+        assertThat(
+                reference.getSource(),
+                is(new MappedSourceBuilder().name("MGI").id("101920").build()));
+        assertThat(reference.getCitationId(), is("23640057"));
+        assertThat(reference.getSourceCategories(), contains("Function", "Subcellular Location"));
+        assertThat(reference.getAnnotation(), emptyString());
     }
 }

--- a/indexer/src/main/java/org/uniprot/store/indexer/uniprotkb/converter/PublicationCategory.java
+++ b/indexer/src/main/java/org/uniprot/store/indexer/uniprotkb/converter/PublicationCategory.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
  */
 public enum PublicationCategory {
     sequence(
-            "Sequence",
+            "Sequences",
             "NUCLEOTIDE SEQUENCE",
             "PROTEIN SEQUENCE",
             "GENOME REANNOTATION",
@@ -91,7 +91,7 @@ public enum PublicationCategory {
             "HEPARIN-BINDING"),
 
     subcell(
-            "Subcell",
+            "Subcellular Location",
             "SUBCELLULAR LOCATION",
             "TOPOLOGY",
             "MEMBRANE TOPOLOGY",
@@ -115,7 +115,7 @@ public enum PublicationCategory {
             "HETERODIMER"),
 
     ptm(
-            "PTM",
+            "PTM / Processing",
             "PHOSPHORYLATION",
             "ACETYLATION",
             "GLYCOSYLATION",
@@ -195,7 +195,7 @@ public enum PublicationCategory {
             "MODELING"),
 
     pathol(
-            "Pathol",
+            "Pathology & Biotech",
             "MUTAGENESIS",
             "DISRUPTION PHENOTYPE",
             "INVOLVEMENT",
@@ -213,7 +213,7 @@ public enum PublicationCategory {
     names("Names", "GENE FAMILY", "NOMENCLATURE", "GENE NAME", "GENE FAMILY AND NOMENCLATURE"),
 
     family(
-            "Family",
+            "Family & Domains",
             "DOMAIN",
             "GENE FAMILY ORGANIZATION",
             "SIMILARITY",

--- a/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/publication/mapper/MappedReferencesToPublicationDocumentBuilderConverter.java
+++ b/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/publication/mapper/MappedReferencesToPublicationDocumentBuilderConverter.java
@@ -56,6 +56,9 @@ public class MappedReferencesToPublicationDocumentBuilderConverter
             type.ifPresent(types::add);
             categories.addAll(mappedReference.getSourceCategories());
         }
+        if(categories.isEmpty()){
+            categories.add("Unclassified");
+        }
 
         docBuilder
                 .id(getUniqueId())

--- a/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/publication/mapper/MappedReferencesToPublicationDocumentBuilderConverter.java
+++ b/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/publication/mapper/MappedReferencesToPublicationDocumentBuilderConverter.java
@@ -35,6 +35,7 @@ public class MappedReferencesToPublicationDocumentBuilderConverter
         implements PairFunction<
                 Tuple2<String, Iterable<MappedReference>>, String, PublicationDocument.Builder> {
     private static final long serialVersionUID = -5482428304872200536L;
+    private static final String UNCLASSIFIED = "Unclassified";
 
     @Override
     public Tuple2<String, PublicationDocument.Builder> call(
@@ -56,8 +57,8 @@ public class MappedReferencesToPublicationDocumentBuilderConverter
             type.ifPresent(types::add);
             categories.addAll(mappedReference.getSourceCategories());
         }
-        if(categories.isEmpty()){
-            categories.add("Unclassified");
+        if (categories.isEmpty()) {
+            categories.add(UNCLASSIFIED);
         }
 
         docBuilder

--- a/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/publication/PublicationDocumentsToHDFSWriterTest.java
+++ b/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/publication/PublicationDocumentsToHDFSWriterTest.java
@@ -202,7 +202,7 @@ class PublicationDocumentsToHDFSWriterTest {
         PublicationDocument kbRN1Doc = extractValue(kbDocs, PublicationDocument::getRefNumber, 1);
 
         assertThat(kbRN1Doc.getCitationId(), is("CI-73HJSSOHL8LGA"));
-        assertThat(kbRN1Doc.getCategories(), contains("Sequence"));
+        assertThat(kbRN1Doc.getCategories(), contains("Sequences"));
 
         MappedPublications mappedPubsForKbRN1 = extractObject(kbRN1Doc);
         assertThat(mappedPubsForKbRN1.getCommunityMappedReferences(), hasSize(0));
@@ -222,7 +222,7 @@ class PublicationDocumentsToHDFSWriterTest {
         assertThat(kbRN1Ref.getSource().getName(), is("UniProtKB reviewed (Swiss-Prot)"));
         assertThat(kbRN1Ref.getSource().getId(), is(nullValue()));
         assertThat(kbRN1Ref.getCitationId(), is("CI-73HJSSOHL8LGA"));
-        assertThat(kbRN1Ref.getSourceCategories(), contains("Sequence"));
+        assertThat(kbRN1Ref.getSourceCategories(), contains("Sequences"));
 
         // check RN 3
         PublicationDocument kbRN3Doc = extractValue(kbDocs, PublicationDocument::getRefNumber, 3);
@@ -230,7 +230,7 @@ class PublicationDocumentsToHDFSWriterTest {
         assertThat(kbRN3Doc.getCitationId(), is("15489334"));
         assertThat(kbRN3Doc.getMainType(), is(UNIPROTKB_REVIEWED.getIntValue()));
         assertThat(kbRN3Doc.getTypes(), contains(UNIPROTKB_REVIEWED.getIntValue()));
-        assertThat(kbRN3Doc.getCategories(), containsInAnyOrder("Sequence"));
+        assertThat(kbRN3Doc.getCategories(), containsInAnyOrder("Sequences"));
 
         MappedPublications mappedPubsForKbRN3 = extractObject(kbRN3Doc);
         assertThat(mappedPubsForKbRN3.getCommunityMappedReferences(), hasSize(0));
@@ -250,7 +250,7 @@ class PublicationDocumentsToHDFSWriterTest {
         assertThat(kbRN4Ref.getSource().getName(), is("UniProtKB reviewed (Swiss-Prot)"));
         assertThat(kbRN4Ref.getSource().getId(), is(nullValue()));
         assertThat(kbRN4Ref.getCitationId(), is("15489334"));
-        assertThat(kbRN4Ref.getSourceCategories(), contains("Sequence"));
+        assertThat(kbRN4Ref.getSourceCategories(), contains("Sequences"));
     }
 
     private void checkCommunityDocuments(List<PublicationDocument> savedDocuments)

--- a/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/publication/mapper/MappedReferencesToPublicationDocumentBuilderConverterTest.java
+++ b/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/publication/mapper/MappedReferencesToPublicationDocumentBuilderConverterTest.java
@@ -165,4 +165,45 @@ class MappedReferencesToPublicationDocumentBuilderConverterTest {
         assertEquals(2, doc.getMainType());
         assertEquals(11, doc.getRefNumber());
     }
+
+    @Test
+    void mapMultipleMappedReferenceWithoutCategory() throws Exception {
+        MappedReferencesToPublicationDocumentBuilderConverter mapper =
+                new MappedReferencesToPublicationDocumentBuilderConverter();
+        String accPub = "P21802_100";
+        List<MappedReference> mappedReferences = new ArrayList<>();
+        mappedReferences.add(
+                new ComputationallyMappedReferenceBuilder()
+                        .citationId("100")
+                        .uniProtKBAccession("P21802")
+                        .source(new MappedSourceBuilder().id("COMP_ID").name("COMP_NAME").build())
+                        .annotation("AnnotationValue")
+                        .build());
+
+        mappedReferences.add(
+                new CommunityMappedReferenceBuilder()
+                        .citationId("100")
+                        .uniProtKBAccession("P21802")
+                        .source(new MappedSourceBuilder().id("CMNT_ID").name("CMNT_NAME").build())
+                        .communityAnnotation(
+                                new CommunityAnnotationBuilder().comment("cmValue").build())
+                        .build());
+
+
+        Tuple2<String, Iterable<MappedReference>> tuple = new Tuple2<>(accPub, mappedReferences);
+        Tuple2<String, PublicationDocument.Builder> result = mapper.call(tuple);
+        assertNotNull(result);
+        assertNotNull(result._1);
+        assertNotNull(result._2);
+        PublicationDocument doc = result._2.build();
+        assertEquals("P21802", doc.getAccession());
+        assertEquals("100", doc.getCitationId());
+        assertEquals("P21802", doc.getAccession());
+        assertTrue(doc.getCategories().contains("Unclassified"));
+        assertTrue(doc.getTypes().contains(0));
+        assertTrue(doc.getTypes().contains(1));
+        assertNotNull(doc.getPublicationMappedReferences());
+        assertEquals(1, doc.getMainType());
+    }
+
 }


### PR DESCRIPTION
Fixes applied for (https://www.ebi.ac.uk/panda/jira/browse/TRM-27044)

Renamed PublicationCategory.java enum label for UniProtKB related publications.
Allow to display all values for category facet, not only top 5 (changed publication.facet.properties)
Add Unclassified value when we do not have any category associated with the publication 
For community publications we were not mapping Subcellular location category. I changed the logic to allow case insensitive input. (Community input is "Subcellular location" and Computationally mapped input is "Subcellular Location")