### PR TITLE
Taxon with trembl count fix

### DIFF
--- a/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/taxonomy/TaxonomyEntryToDocumentMapper.java
+++ b/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/taxonomy/TaxonomyEntryToDocumentMapper.java
@@ -43,10 +43,11 @@ public class TaxonomyEntryToDocumentMapper
                 taxonomiesWith.add("1_uniprotkb");
                 taxonomiesWith.add("2_reviewed");
             }
-            if (statisticsWrapper.isOrganismUnreviewedProtein()
-                    && !statisticsWrapper.isOrganismUnreviewedProtein()) {
-                taxonomiesWith.add("1_uniprotkb");
+            if (statisticsWrapper.isOrganismUnreviewedProtein()) {
                 taxonomiesWith.add("3_unreviewed");
+                if (!statisticsWrapper.isOrganismReviewedProtein()) {
+                    taxonomiesWith.add("1_uniprotkb");
+                }
             }
             if (statistics.hasReferenceProteomeCount()) {
                 taxonomiesWith.add("4_reference");

--- a/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/taxonomy/TaxonomyDocumentsToHDFSWriterTest.java
+++ b/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/taxonomy/TaxonomyDocumentsToHDFSWriterTest.java
@@ -116,8 +116,10 @@ class TaxonomyDocumentsToHDFSWriterTest {
         assertTrue(document.getOtherNames().contains("second name"));
 
         assertNotNull(document.getTaxonomiesWith());
+        assertEquals(5, document.getTaxonomiesWith().size());
         assertTrue(document.getTaxonomiesWith().contains("1_uniprotkb"));
         assertTrue(document.getTaxonomiesWith().contains("2_reviewed"));
+        assertTrue(document.getTaxonomiesWith().contains("3_unreviewed"));
         assertTrue(document.getTaxonomiesWith().contains("4_reference"));
         assertTrue(document.getTaxonomiesWith().contains("5_proteome"));
 

--- a/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/taxonomy/TaxonomyEntryToDocumentMapperTest.java
+++ b/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/taxonomy/TaxonomyEntryToDocumentMapperTest.java
@@ -1,0 +1,163 @@
+package org.uniprot.store.spark.indexer.taxonomy;
+
+import org.apache.spark.api.java.Optional;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.uniprot.core.taxonomy.TaxonomyEntry;
+import org.uniprot.core.taxonomy.TaxonomyRank;
+import org.uniprot.core.taxonomy.TaxonomyStatistics;
+import org.uniprot.core.taxonomy.impl.TaxonomyEntryBuilder;
+import org.uniprot.core.taxonomy.impl.TaxonomyStatisticsBuilder;
+import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
+import org.uniprot.core.uniprotkb.taxonomy.impl.TaxonomyBuilder;
+import org.uniprot.store.search.document.taxonomy.TaxonomyDocument;
+import org.uniprot.store.spark.indexer.taxonomy.mapper.model.TaxonomyStatisticsWrapper;
+import scala.Tuple2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaxonomyEntryToDocumentMapperTest {
+
+    @Test
+    void canMapOrganismWithReviewedUniprotKbEntries() throws Exception {
+        TaxonomyEntryToDocumentMapper mapper = new TaxonomyEntryToDocumentMapper();
+        TaxonomyEntry entry = getTaxonomyEntry();
+        TaxonomyStatistics stats = new TaxonomyStatisticsBuilder()
+                .reviewedProteinCount(10L)
+                .build();
+        TaxonomyStatisticsWrapper wrapper = TaxonomyStatisticsWrapper.builder()
+                .organismReviewedProtein(true)
+                .statistics(stats)
+                .build();
+        Tuple2<TaxonomyEntry, Optional<TaxonomyStatisticsWrapper>> tuple = new Tuple2<>(entry,Optional.of(wrapper));
+
+        TaxonomyDocument result = mapper.call(tuple);
+
+        assertNotNull(result);
+        assertEquals(9606L, result.getTaxId());
+        assertNotNull(result.getTaxonomiesWith());
+        assertEquals(2, result.getTaxonomiesWith().size());
+        assertTrue(result.getTaxonomiesWith().contains("1_uniprotkb"));
+        assertTrue(result.getTaxonomiesWith().contains("2_reviewed"));
+    }
+
+    @Test
+    void canMapOrganismWithUnreviewedUniprotKbEntries() throws Exception {
+        TaxonomyEntryToDocumentMapper mapper = new TaxonomyEntryToDocumentMapper();
+
+        TaxonomyEntry entry = getTaxonomyEntry();
+        TaxonomyStatistics stats = new TaxonomyStatisticsBuilder()
+                .unreviewedProteinCount(10L)
+                .build();
+        TaxonomyStatisticsWrapper wrapper = TaxonomyStatisticsWrapper.builder()
+                .organismUnreviewedProtein(true)
+                .statistics(stats)
+                .build();
+        Tuple2<TaxonomyEntry, Optional<TaxonomyStatisticsWrapper>> tuple = new Tuple2<>(entry,Optional.of(wrapper));
+
+        TaxonomyDocument result = mapper.call(tuple);
+
+        assertNotNull(result);
+        assertEquals(9606L, result.getTaxId());
+        assertNotNull(result.getTaxonomiesWith());
+        assertEquals(2, result.getTaxonomiesWith().size());
+        assertTrue(result.getTaxonomiesWith().contains("1_uniprotkb"));
+        assertTrue(result.getTaxonomiesWith().contains("3_unreviewed"));
+    }
+
+    @Test
+    void canMapOrganismWithReferenceProteome() throws Exception {
+        TaxonomyEntryToDocumentMapper mapper = new TaxonomyEntryToDocumentMapper();
+
+        TaxonomyEntry entry = getTaxonomyEntry();
+        TaxonomyStatistics stats = new TaxonomyStatisticsBuilder()
+                .referenceProteomeCount(10)
+                .build();
+        TaxonomyStatisticsWrapper wrapper = TaxonomyStatisticsWrapper.builder()
+                .statistics(stats)
+                .build();
+        Tuple2<TaxonomyEntry, Optional<TaxonomyStatisticsWrapper>> tuple = new Tuple2<>(entry,Optional.of(wrapper));
+
+        TaxonomyDocument result = mapper.call(tuple);
+
+        assertNotNull(result);
+        assertEquals(9606L, result.getTaxId());
+        assertNotNull(result.getTaxonomiesWith());
+        assertEquals(2, result.getTaxonomiesWith().size());
+        assertTrue(result.getTaxonomiesWith().contains("4_reference"));
+        assertTrue(result.getTaxonomiesWith().contains("5_proteome"));
+    }
+
+    @Test
+    void canMapOrganismWithProteome() throws Exception {
+        TaxonomyEntryToDocumentMapper mapper = new TaxonomyEntryToDocumentMapper();
+        TaxonomyEntry entry = getTaxonomyEntry();
+        TaxonomyStatistics stats = new TaxonomyStatisticsBuilder()
+                .proteomeCount(10)
+                .build();
+        TaxonomyStatisticsWrapper wrapper = TaxonomyStatisticsWrapper.builder()
+                .statistics(stats)
+                .build();
+        Tuple2<TaxonomyEntry, Optional<TaxonomyStatisticsWrapper>> tuple = new Tuple2<>(entry,Optional.of(wrapper));
+
+        TaxonomyDocument result = mapper.call(tuple);
+
+        assertNotNull(result);
+        assertEquals(9606L, result.getTaxId());
+        assertNotNull(result.getTaxonomiesWith());
+        assertEquals(1, result.getTaxonomiesWith().size());
+        assertTrue(result.getTaxonomiesWith().contains("5_proteome"));
+    }
+
+    @Test
+    void mapWithAllTaxonomiesWith() throws Exception {
+        TaxonomyEntryToDocumentMapper mapper = new TaxonomyEntryToDocumentMapper();
+        TaxonomyEntry entry = getTaxonomyEntry();
+        TaxonomyStatistics stats = new TaxonomyStatisticsBuilder()
+                .proteomeCount(10)
+                .referenceProteomeCount(20)
+                .build();
+        TaxonomyStatisticsWrapper wrapper = TaxonomyStatisticsWrapper.builder()
+                .organismReviewedProtein(true)
+                .organismUnreviewedProtein(true)
+                .statistics(stats)
+                .build();
+        Tuple2<TaxonomyEntry, Optional<TaxonomyStatisticsWrapper>> tuple = new Tuple2<>(entry,Optional.of(wrapper));
+
+        TaxonomyDocument result = mapper.call(tuple);
+
+        assertNotNull(result);
+        assertEquals(9606L, result.getTaxId());
+        assertNotNull(result.getTaxonomiesWith());
+        assertEquals(5, result.getTaxonomiesWith().size());
+        assertTrue(result.getTaxonomiesWith().contains("1_uniprotkb"));
+        assertTrue(result.getTaxonomiesWith().contains("2_reviewed"));
+        assertTrue(result.getTaxonomiesWith().contains("3_unreviewed"));
+        assertTrue(result.getTaxonomiesWith().contains("4_reference"));
+        assertTrue(result.getTaxonomiesWith().contains("5_proteome"));
+    }
+
+    @Test
+    void mapWhenRootReturnNull() throws Exception {
+        TaxonomyEntryToDocumentMapper mapper = new TaxonomyEntryToDocumentMapper();
+
+        TaxonomyEntry entry = new TaxonomyEntryBuilder()
+                .taxonId(1L)
+                .build();
+        Tuple2<TaxonomyEntry, Optional<TaxonomyStatisticsWrapper>> tuple = new Tuple2<>(entry,Optional.empty());
+        TaxonomyDocument result = mapper.call(tuple);
+        assertNull(result);
+    }
+
+    @NotNull
+    private TaxonomyEntry getTaxonomyEntry() {
+        Taxonomy parent = new TaxonomyBuilder()
+                .taxonId(10L)
+                .build();
+        return new TaxonomyEntryBuilder()
+                .taxonId(9606L)
+                .parent(parent)
+                .rank(TaxonomyRank.FAMILY)
+                .build();
+    }
+}


### PR DESCRIPTION
During the deploy we notice that trembl entries were not being counted in Taxonomies With Facet.
Fixed it.