### PR TITLE
TRM-29103: idMapping for deleted UniProtKB entries does not show status

### DIFF
--- a/uniprot-config/src/main/resources/return-fields-config/uniprotkb-return-fields.json
+++ b/uniprot-config/src/main/resources/return-fields-config/uniprotkb-return-fields.json
@@ -700,6 +700,7 @@
     "childNumber": 6,
     "itemType": "SINGLE",
     "includeInSwagger": true,
+    "isRequiredForJson": true,
     "isDefaultForTsv": true,
     "defaultForTsvOrder" : 2,
     "name": "reviewed",
@@ -1548,5 +1549,12 @@
     "groupName": "Family and domain",
     "isDatabaseGroup": true,
     "id": "family_and_domain"
+  },
+  {
+    "itemType": "SINGLE",
+    "id": "inactive_reason",
+    "isRequiredForJson": true,
+    "name": "inactiveReason",
+    "paths": ["inactiveReason"]
   }
 ]

--- a/uniprot-config/src/test/java/org/uniprot/store/config/returnfield/config/impl/UniParcReturnFieldConfigImplIT.java
+++ b/uniprot-config/src/test/java/org/uniprot/store/config/returnfield/config/impl/UniParcReturnFieldConfigImplIT.java
@@ -5,11 +5,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -73,6 +76,30 @@ class UniParcReturnFieldConfigImplIT {
         System.out.println(returnFieldName + " : " + mappedField.get(returnFieldName));
         assertNotNull(mappedField.get(returnFieldName));
         assertFalse(mappedField.get(returnFieldName).isEmpty());
+    }
+
+    @Test
+    void testInternalReturnFields() {
+        List<String> expectedInternalNames =
+                List.of(
+                        "database",
+                        "ncbiGi",
+                        "active",
+                        "timeline",
+                        "version",
+                        "version_uniparc",
+                        "oldestCrossRefCreated",
+                        "mostRecentCrossRefUpdated");
+        List<ReturnField> internal =
+                returnFieldConfig.getReturnFields().stream()
+                        .filter(rf -> Objects.isNull(rf.getParentId()))
+                        .collect(Collectors.toList());
+        assertNotNull(internal);
+        assertEquals(8, internal.size());
+        List<String> internalNames =
+                internal.stream().map(ReturnField::getName).collect(Collectors.toList());
+
+        assertEquals(expectedInternalNames, internalNames);
     }
 
     private static Stream<Arguments> provideSearchSortFields() {

--- a/uniprot-config/src/test/java/org/uniprot/store/config/returnfield/config/impl/UniProtKBReturnFieldConfigImplIT.java
+++ b/uniprot-config/src/test/java/org/uniprot/store/config/returnfield/config/impl/UniProtKBReturnFieldConfigImplIT.java
@@ -76,7 +76,8 @@ class UniProtKBReturnFieldConfigImplIT {
         UniProtKBEntryValueMapper entityValueMapper = new UniProtKBEntryValueMapper();
         Map<String, String> mappedField =
                 entityValueMapper.mapEntity(entry, Collections.singletonList(returnFieldName));
-        if (!returnFieldName.equals("tools")) { // Tools is the only one not supported by TSV
+        // fields not supported by TSV
+        if (!returnFieldName.equals("tools") && !returnFieldName.equals("inactiveReason")) {
             assertNotNull(mappedField.get(returnFieldName));
             assertFalse(mappedField.get(returnFieldName).isEmpty());
         }

--- a/uniprot-config/src/test/java/org/uniprot/store/config/returnfield/config/impl/UniProtKBReturnFieldConfigImplIT.java
+++ b/uniprot-config/src/test/java/org/uniprot/store/config/returnfield/config/impl/UniProtKBReturnFieldConfigImplIT.java
@@ -5,10 +5,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.uniprot.store.config.returnfield.config.impl.UniProtKBReturnFieldConfigImpl.DBNAMEPATH;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -92,6 +90,19 @@ class UniProtKBReturnFieldConfigImplIT {
         assertTrue(dbSNP.isPresent());
         assertEquals(1, dbSNP.get().getPaths().size());
         assertEquals(DBNAMEPATH.get("dbsnp"), dbSNP.get().getPaths().get(0));
+    }
+
+    @Test
+    void testInternalReturnFields() {
+        List<ReturnField> internal =
+                returnFieldConfig.getReturnFields().stream()
+                        .filter(rf -> Objects.isNull(rf.getParentId()))
+                        .collect(Collectors.toList());
+        assertNotNull(internal);
+        assertEquals(1, internal.size());
+        ReturnField inactiveField = internal.get(0);
+        assertEquals("inactiveReason", inactiveField.getName());
+        assertTrue(inactiveField.getIsRequiredForJson());
     }
 
     @Test

--- a/uniprot-config/src/test/java/org/uniprot/store/config/returnfield/factory/ReturnFieldConfigFactoryTest.java
+++ b/uniprot-config/src/test/java/org/uniprot/store/config/returnfield/factory/ReturnFieldConfigFactoryTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 import org.uniprot.store.config.UniProtDataType;
@@ -37,6 +38,7 @@ class ReturnFieldConfigFactoryTest {
         Map<String, List<ReturnField>> groupToSingleFieldMap =
                 config.getAllFields().stream()
                         .filter(field -> field.getItemType().equals(ReturnFieldItemType.SINGLE))
+                        .filter(field -> Objects.nonNull(field.getParentId()))
                         .collect(groupingBy(ReturnField::getParentId));
 
         // check the defined groups are the same as the union of all children's parents


### PR DESCRIPTION
idMapping for deleted UniProtKB entries does not return inactiveStatus