### PR TITLE
Improve UniParcId index size, by adding a special field type with a r…

### DIFF
--- a/index-config/src/main/solr-config/uniprot-collections/uniparc/conf/schema.xml
+++ b/index-config/src/main/solr-config/uniprot-collections/uniparc/conf/schema.xml
@@ -20,7 +20,7 @@
 		stored="false" required="false" multiValued="true" docValues="true" />
 	<field name="database" type="basic_ci" indexed="true"
 		stored="false" required="false" multiValued="true" />
-	<field name="dbid" type="basic_ci" indexed="true" stored="false"
+	<field name="dbid" type="dbid_ci" indexed="true" stored="false"
 		required="false" multiValued="true" />
 	<field name="active" type="basic_ci" indexed="true"
 		stored="false" required="false" multiValued="true" />
@@ -67,6 +67,20 @@
 		</analyzer>
 		<analyzer type="query">
 			<tokenizer class="solr.WhitespaceTokenizerFactory" />
+			<filter class="solr.LowerCaseFilterFactory" />
+		</analyzer>
+	</fieldType>
+
+	<fieldType name="dbid_ci" class="solr.TextField"
+		sortMissingLast="true" omitNorms="true" positionIncrementGap="100">
+		<analyzer type="index">
+			<tokenizer class="solr.PatternTokenizerFactory"
+				pattern="\.(?=[^.]*$)" />
+			<filter class="solr.LowerCaseFilterFactory" />
+		</analyzer>
+		<analyzer type="query">
+			<tokenizer class="solr.PatternTokenizerFactory"
+				pattern="\.(?=[^.]*$)" />
 			<filter class="solr.LowerCaseFilterFactory" />
 		</analyzer>
 	</fieldType>

--- a/indexer/src/main/java/org/uniprot/store/indexer/uniparc/UniParcDocumentConverter.java
+++ b/indexer/src/main/java/org/uniprot/store/indexer/uniparc/UniParcDocumentConverter.java
@@ -5,6 +5,7 @@ import static org.uniprot.store.indexer.uniprotkb.converter.UniProtEntryConverte
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.uniprot.core.uniparc.SequenceFeature;
 import org.uniprot.core.uniparc.UniParcCrossReference;
@@ -66,7 +67,11 @@ public class UniParcDocumentConverter implements DocumentConverter<Entry, UniPar
     private void processDbReference(UniParcCrossReference xref, UniParcDocumentBuilder builder) {
         UniParcDatabase type = xref.getDatabase();
 
-        builder.dbId(xref.getId());
+        String dbId = xref.getId();
+        if (Objects.nonNull(xref.getVersion()) && xref.getVersion() > 0) {
+            dbId += "." + xref.getVersion();
+        }
+        builder.dbId(dbId);
 
         Map.Entry<String, String> dbTypeData = UniParcConfigUtil.getDBNameValue(type);
         if (xref.isActive()) {

--- a/indexer/src/test/java/org/uniprot/store/indexer/uniparc/UniParcDocumentConverterTest.java
+++ b/indexer/src/test/java/org/uniprot/store/indexer/uniparc/UniParcDocumentConverterTest.java
@@ -55,19 +55,19 @@ class UniParcDocumentConverterTest {
                 CoreMatchers.hasItems(
                         "Q02297-8",
                         "ENSP00000498811",
-                        "AAA27261",
-                        "A0A038DI27",
-                        "A0A038DND5",
-                        "KFT92747",
-                        "KFU20332",
-                        "WP_001001975",
-                        "YP_005181896",
-                        "YP_005233094",
+                        "AAA27261.1",
+                        "A0A038DI27.1",
+                        "A0A038DND5.1",
+                        "KFT92747.1",
+                        "KFU20332.1",
+                        "WP_001001975.1",
+                        "YP_005181896.1",
+                        "YP_005233094.1",
                         "ETC11569",
                         "fig|1218145.3.peg.2041",
                         "fig|99287.1.peg.1951",
                         "fig|99287.12.peg.2148",
-                        "A0A038DI37",
+                        "A0A038DI37.1",
                         "107675830"));
 
         assertEquals(9, uniParcDocument.getDatabases().size());

--- a/integration-test/src/test/java/org/uniprot/store/indexer/search/uniparc/TestUtils.java
+++ b/integration-test/src/test/java/org/uniprot/store/indexer/search/uniparc/TestUtils.java
@@ -32,10 +32,15 @@ final class TestUtils {
     }
 
     static DbReferenceType createXref(String dbType, String id, String active) {
+        return createXref(dbType, id, active, 0);
+    }
+
+    static DbReferenceType createXref(String dbType, String id, String active, Integer version) {
         DbReferenceType xref = xmlFactory.createDbReferenceType();
         xref.setActive(active);
         xref.setType(dbType);
         xref.setId(id);
+        xref.setVersion(version);
         GregorianCalendar gcal = new GregorianCalendar();
         try {
             XMLGregorianCalendar xgcal =

--- a/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/uniparc/converter/UniParcDocumentConverter.java
+++ b/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/uniparc/converter/UniParcDocumentConverter.java
@@ -36,11 +36,11 @@ public class UniParcDocumentConverter implements DocumentConverter<UniParcEntry,
             UniParcCrossReference xref, UniParcDocument.UniParcDocumentBuilder builder) {
         UniParcDatabase type = xref.getDatabase();
 
-        builder.dbId(xref.getId());
-
-        if (Objects.nonNull(xref.getVersion())) {
-            builder.dbId(xref.getId() + "." + xref.getVersion());
+        String dbId = xref.getId();
+        if (Objects.nonNull(xref.getVersion()) && xref.getVersion() > 0) {
+            dbId += "." + xref.getVersion();
         }
+        builder.dbId(dbId);
 
         Map.Entry<String, String> dbTypeData = UniParcConfigUtil.getDBNameValue(type);
         if (xref.isActive()) {

--- a/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/uniparc/converter/UniParcDocumentConverterTest.java
+++ b/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/uniparc/converter/UniParcDocumentConverterTest.java
@@ -50,11 +50,10 @@ class UniParcDocumentConverterTest {
         assertTrue(result.getDatabasesFacets().contains(UniParcDatabase.EMBL.getIndex()));
 
         assertNotNull(result.getDbIds());
-        assertEquals(4, result.getDbIds().size());
-        assertTrue(result.getDbIds().contains("UniProtKB/Swiss-ProtIdValue-true"));
-        assertTrue(result.getDbIds().contains("UniProtKB/Swiss-ProtIdValue-false"));
+        assertEquals(3, result.getDbIds().size());
+        assertTrue(result.getDbIds().contains("UniProtKB/Swiss-ProtIdValue-true.1"));
+        assertTrue(result.getDbIds().contains("UniProtKB/Swiss-ProtIdValue-false.1"));
         assertTrue(result.getDbIds().contains("inactiveIdValue.99"));
-        assertTrue(result.getDbIds().contains("inactiveIdValue"));
 
         assertNotNull(result.getActives());
         assertEquals(1, result.getActives().size());
@@ -97,12 +96,12 @@ class UniParcDocumentConverterTest {
         assertTrue(result.getActives().contains("isoforms"));
 
         assertNotNull(result.getDbIds());
-        assertEquals(4, result.getDbIds().size());
-        assertTrue(result.getDbIds().contains("UniProtKB/Swiss-Prot protein isoformsIdValue-true"));
+        assertEquals(3, result.getDbIds().size());
         assertTrue(
-                result.getDbIds().contains("UniProtKB/Swiss-Prot protein isoformsIdValue-false"));
+                result.getDbIds().contains("UniProtKB/Swiss-Prot protein isoformsIdValue-true.1"));
+        assertTrue(
+                result.getDbIds().contains("UniProtKB/Swiss-Prot protein isoformsIdValue-false.1"));
         assertTrue(result.getDbIds().contains("inactiveIdValue.99"));
-        assertTrue(result.getDbIds().contains("inactiveIdValue"));
 
         validateDocumentCommonValues(result);
     }
@@ -172,6 +171,7 @@ class UniParcDocumentConverterTest {
     private UniParcCrossReference getDatabaseCrossReferences(UniParcDatabase type, boolean active) {
         return new UniParcCrossReferenceBuilder()
                 .id(type.getName() + "IdValue-" + active)
+                .version(1)
                 .database(type)
                 .organism(getOrganism())
                 .geneName("geneNameValue")


### PR DESCRIPTION
Improve UniParcId index size, by adding a special field type with a regex tokenizer to split the version, this way we do not need to duplicate field value with and without version.