### PR TITLE
count representative proteome as reference proteome

### DIFF
--- a/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/proteome/mapper/ProteomeTaxonomyStatisticsMapper.java
+++ b/spark-indexer/src/main/java/org/uniprot/store/spark/indexer/proteome/mapper/ProteomeTaxonomyStatisticsMapper.java
@@ -15,7 +15,10 @@ public class ProteomeTaxonomyStatisticsMapper
         implements PairFunction<ProteomeEntry, String, TaxonomyStatisticsWrapper> {
     private static final long serialVersionUID = -4013227058179840505L;
     private static final Set<ProteomeType> REFERENCE_PROTEOME_TYPES =
-            EnumSet.of(ProteomeType.REFERENCE, ProteomeType.REFERENCE_AND_REPRESENTATIVE);
+            EnumSet.of(
+                    ProteomeType.REFERENCE,
+                    ProteomeType.REFERENCE_AND_REPRESENTATIVE,
+                    ProteomeType.REPRESENTATIVE);
 
     @Override
     public Tuple2<String, TaxonomyStatisticsWrapper> call(ProteomeEntry entry) throws Exception {

--- a/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/proteome/mapper/ProteomeTaxonomyStatisticsMapperTest.java
+++ b/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/proteome/mapper/ProteomeTaxonomyStatisticsMapperTest.java
@@ -68,4 +68,22 @@ class ProteomeTaxonomyStatisticsMapperTest {
         assertEquals(0, statistics.getReferenceProteomeCount());
         assertEquals(1, statistics.getProteomeCount());
     }
+
+    @Test
+    void mapRepresentativeProteome() throws Exception {
+        ProteomeTaxonomyStatisticsMapper mapper = new ProteomeTaxonomyStatisticsMapper();
+        ProteomeEntry entry =
+                new ProteomeEntryBuilder()
+                        .proteomeId("UP000000001")
+                        .proteomeType(ProteomeType.REPRESENTATIVE)
+                        .taxonomy(new TaxonomyBuilder().taxonId(100L).build())
+                        .build();
+        Tuple2<String, TaxonomyStatisticsWrapper> result = mapper.call(entry);
+        assertNotNull(result);
+        assertEquals("100", result._1);
+        assertNotNull(result._2.getStatistics());
+        TaxonomyStatistics statistics = result._2.getStatistics();
+        assertEquals(1, statistics.getReferenceProteomeCount());
+        assertEquals(1, statistics.getProteomeCount());
+    }
 }


### PR DESCRIPTION
See https://embl.atlassian.net/browse/TRM-32753 for details.
### Test output store
[INFO] UniProt Store Aggregator ........................... SUCCESS [  1.350 s]
[INFO] uniprot-index-config ............................... SUCCESS [  1.077 s]
[INFO] uniprot-config ..................................... SUCCESS [ 28.270 s]
[INFO] uniprot-search ..................................... SUCCESS [ 14.849 s]
[INFO] common-job ......................................... SUCCESS [ 10.002 s]
[INFO] uniprot-indexer .................................... SUCCESS [01:47 min]
[INFO] uniprot-datastore .................................. SUCCESS [01:21 min]
[INFO] spark-indexer ...................................... SUCCESS [06:29 min]
[INFO] uniprot-indexer-integration-test ................... SUCCESS [04:09 min]
[INFO] jacoco-aggregate-report ............................ SUCCESS [  2.953 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14:46 min
[INFO] Finished at: 2025-05-30T17:25:30+01:00